### PR TITLE
docs: fix outdated SOAP corporate proxy page (fixes #777)

### DIFF
--- a/pages/security/SOAP-method-invocation-through-Corporate-Proxy.md
+++ b/pages/security/SOAP-method-invocation-through-Corporate-Proxy.md
@@ -1,102 +1,92 @@
+# SOAP Method Invocation Through Corporate Proxy
 
-You need to use a HttpClient ie override the BasicHttpClient and set proxies to it as below-
-```java
-        Step-1)
-        CredentialsProvider credsProvider = createProxyCredentialsProvider(proxyHost, proxyPort, proxyUserName, proxyPassword);
+When your test environment is behind a corporate proxy, you need to override the default `BasicHttpClient` and configure proxy settings. Zerocode provides two built-in HTTP clients for this.
 
-        Step-2)
-        HttpHost proxy = new HttpHost(proxyHost, proxyPort);
- 
-        Step-3) method Step-1
-        private CredentialsProvider createProxyCredentialsProvider(String proxyHost, int proxyPort, String proxyUserName, String proxyPassword) {
+## Available Corporate Proxy HTTP Clients
 
-                CredentialsProvider credsProvider = new BasicCredentialsProvider();
-        
-                credsProvider.setCredentials(
-        
-                        new AuthScope(proxyHost, proxyPort),
-        
-                        new UsernamePasswordCredentials(proxyUserName, proxyPassword));
-        
-                return credsProvider;
-        }
- 
-        Step-4) 
-        Set the values from Step-1 and Step-2
-        
-        HttpClients.custom()
+- `SslTrustCorporateProxyHttpClient` — Routes requests through the proxy with SSL trust enabled (accepts all certificates). Use this when your SOAP endpoint uses HTTPS with self-signed or internal certificates.
+- `CorporateProxyNoSslContextHttpClient` — Routes requests through the proxy without an SSL context. Use this when SSL is not required.
 
-                .setSSLContext(sslContext)
+Both clients are in the package `org.jsmart.zerocode.core.httpclient.ssl`.
 
-                .setSSLHostnameVerifier(new NoopHostnameVerifier())
+## How to Use
 
-                .setDefaultCookieStore(cookieStore)
+### Step 1 — Properties Configuration
 
-                .setDefaultCredentialsProvider(credsProvider)    //<------------- From Step-1
+Create a properties file with your SOAP host and corporate proxy details:
 
-                .setProxy(proxy)                                 //<------------- From Step-2
-
-                .build();
-```
-
-You can inject the Corporate Proxy details to the custom {{HttpClient}} li below from a config file simply by annotating the key names from the host config file which is used by the runner for mentioning host and port.
-
-e.g.:
-
-See an example here(Client)-
-https://github.com/authorjapps/zerocode/blob/master/src/main/java/org/jsmart/zerocode/core/httpclient/soap/SoapCorporateProxySslHttpClient.java
-
-Usage example here(Test):
-https://github.com/authorjapps/zerocode/blob/master/src/test/java/org/jsmart/zerocode/core/soap/SoapCorpProxySslHttpClientTest.java
-
-How to use?
-```java
-@UseHttpClient(SoapCorporateProxySslHttpClient.class)
-@TargetEnv("soap_host_with_corp_proxy.properties")
-@RunWith(ZeroCodeUnitRunner.class)
-public class SoapCorpProxySslHttpClientTest {
-
-    @Ignore
-    @Test
-    @Scenario("foo/bar/soap_test_case_file.json")
-    public void testSoapWithCorpProxyEnabled() throws Exception {
-
-    }
-}
-```
-
-### Explanation:
-
-```java
-@TargetEnv("hello_world_host.properties")
-@RunWith(ZeroCodeUnitRunner.class)
-public class HelloWorldTest {
-     // @Test
-     // tests here
-}
-
-soap_host_with_corp_proxy.properties
----------------------------
+```properties
+                       soap_host_with_corp_proxy.properties
+                       ------------------------------------
 # Web Server host and port
 web.application.endpoint.host=https://soap-server-host/ServiceName
 web.application.endpoint.port=443
-
 # Web Service context; Leave it blank in case you do not have a common context
 web.application.endpoint.context=
 
-#sample test purpose - if you remove this from ehre, then make sure to remove from Java file
+# Corporate proxy settings
 corporate.proxy.host=http://exam.corporate-proxy-host.co.uk
 corporate.proxy.port=80
 corporate.proxy.username=HAVYSTARUSER
 corporate.proxy.password=i#am#here#for#soap#
+```
 
+### Step 2 — Annotate Your Test Class
 
-Your HttpClient:
-----------------
-See-
-https://hc.apache.org/httpcomponents-client-ga/httpclient/examples/org/apache/http/examples/client/ClientProxyAuthentication.java
+Use `@UseHttpClient` to tell Zerocode to route requests through the proxy, and `@TargetEnv` to point to your properties file:
 
-public class YourHttpClient {
+```java
+@UseHttpClient(SslTrustCorporateProxyHttpClient.class)       // <--- Use proxy client
+@TargetEnv("soap_host_with_corp_proxy.properties")            // <--- Host + proxy config
+@RunWith(ZeroCodeUnitRunner.class)
+public class SoapCorpProxyTest {
+
+    @Test
+    @JsonTestCase("soap_tests/soap_via_proxy_test.json")      // <--- Your SOAP scenario
+    public void testSoapThroughProxy() throws Exception {
+    }
+}
+```
+
+For the non-SSL variant, swap the client:
+
+```java
+@UseHttpClient(CorporateProxyNoSslContextHttpClient.class)    // <--- No SSL context
+```
+
+### Step 3 — Write Your SOAP Scenario
+
+The SOAP test scenario is the same whether or not you use a proxy — the proxy handling is transparent:
+
+```json
+{
+    "scenarioName": "SOAP currency conversion via corporate proxy",
+    "steps": [
+        {
+            "name": "invoke_currency_conversion",
+            "url": "/CurrencyConvertor.asmx",
+            "operation": "POST",
+            "request": {
+                "headers": {
+                    "Content-Type": "text/xml; charset=utf-8",
+                    "SOAPAction": "http://www.webserviceX.NET/ConversionRate"
+                },
+                "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soap:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Body>\n    <ConversionRate xmlns=\"http://www.webserviceX.NET/\">\n      <FromCurrency>AFA</FromCurrency>\n      <ToCurrency>GBP</ToCurrency>\n    </ConversionRate>\n  </soap:Body>\n</soap:Envelope>"
+            },
+            "assertions": {
+                "status": 200
+            }
+        }
+    ]
+}
+```
+
+## How It Works Under the Hood
+
+The proxy client injects the corporate proxy details from your properties file using `@Named` annotations:
+
+```java
+public class SslTrustCorporateProxyHttpClient extends BasicHttpClient {
 
     @Inject
     @Named("corporate.proxy.host")
@@ -104,7 +94,7 @@ public class YourHttpClient {
 
     @Inject
     @Named("corporate.proxy.port")
-    private String proxyPort;
+    private int proxyPort;
 
     @Inject
     @Named("corporate.proxy.username")
@@ -114,6 +104,21 @@ public class YourHttpClient {
     @Named("corporate.proxy.password")
     private String proxyPassword;
 
-    // Build the client using these.
+    // Builds an HttpClient with proxy credentials and SSL trust
 }
 ```
+
+You can also create your own custom `HttpClient` by extending `BasicHttpClient` and injecting the same proxy properties. See the [Apache HttpClient proxy authentication example](https://hc.apache.org/httpcomponents-client-ga/httpclient/examples/org/apache/http/examples/client/ClientProxyAuthentication.java) for reference.
+
+## When to Use Which Client
+
+| Client | Use When |
+|--------|----------|
+| `SslTrustCorporateProxyHttpClient` | SOAP endpoint uses HTTPS and you need to bypass certificate validation (e.g. self-signed certs in test environments) |
+| `CorporateProxyNoSslContextHttpClient` | SOAP endpoint does not require SSL, or SSL is handled separately |
+
+## Source Code Reference
+
+- [SslTrustCorporateProxyHttpClient.java](https://github.com/authorjapps/zerocode/blob/master/core/src/main/java/org/jsmart/zerocode/core/httpclient/ssl/SslTrustCorporateProxyHttpClient.java)
+- [CorporateProxyNoSslContextHttpClient.java](https://github.com/authorjapps/zerocode/blob/master/core/src/main/java/org/jsmart/zerocode/core/httpclient/ssl/CorporateProxyNoSslContextHttpClient.java)
+- [SoapCorpProxySslHttpClientTest.java](https://github.com/authorjapps/zerocode/blob/master/core/src/test/java/org/jsmart/zerocode/core/soap/SoapCorpProxySslHttpClientTest.java)


### PR DESCRIPTION
Updated pages/security/SOAP-method-invocation-through-Corporate-Proxy.md with:

Corrected class name from SoapCorporateProxySslHttpClient to SslTrustCorporateProxyHttpClient
Fixed broken GitHub links to use current path structure (core/src/main/java/...)
Added CorporateProxyNoSslContextHttpClient as an alternative option
Added SOAP scenario example and comparison table